### PR TITLE
Signed-off-by: Joey Smith <jsmith@webinertia.net>

### DIFF
--- a/src/ConfigProviderInterface.php
+++ b/src/ConfigProviderInterface.php
@@ -6,5 +6,6 @@ namespace Axleus\Core;
 
 interface ConfigProviderInterface
 {
+    public const string CONFIG_MANAGER_TARGET_FILE = '';
     public function getAxleusConfig(): array;
 }


### PR DESCRIPTION
Create public string const to allow all ConfigProviders to provide their target config file names to be consumed by ConfigManager