### PR TITLE
removes mimmi20/mezzio-navigation since it is required by mimmi20/mezzio-navigation-laminasviewrenderer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "laminas/laminas-i18n": "^2.29",
         "mezzio/mezzio": "^3.7",
         "mezzio/mezzio-laminasviewrenderer": "^2.15",
-        "mimmi20/mezzio-navigation": "^4.0.1",
         "mimmi20/mezzio-navigation-laminasviewrenderer": "^4.0.0 || ^5.0.0",
         "psr/clock": "^1.0",
         "ramsey/uuid": "^4.7"


### PR DESCRIPTION
Signed-off-by: Joey Smith <jsmith@webinertia.net>

Signed-off-by: Joey Smith <jsmith@webinertia.net>